### PR TITLE
Alterado ContasClassicas.ContaExiste pra permitir consultar por documento

### DIFF
--- a/MoipCSharp/MoipCSharp/Controllers/ContasClassicasController.cs
+++ b/MoipCSharp/MoipCSharp/Controllers/ContasClassicasController.cs
@@ -29,9 +29,9 @@ namespace MoipCSharp.Controllers
         }
         #endregion Singleton Pattern
 
-        public async Task<HttpStatusCode> ContaExiste(string email)
+        public async Task<HttpStatusCode> ContaExiste(string emailOuDocumento)
         {
-            HttpResponseMessage response = await ClientInstance.GetAsync($"v2/accounts/exists?email={email}");
+            HttpResponseMessage response = await ClientInstance.GetAsync($"v2/accounts/exists?{(emailOuDocumento.Contains("@")?"email": "tax_document")}={emailOuDocumento}");
             if (!response.IsSuccessStatusCode)
             {
                 string content = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
A consulta se uma conta já existe pode ser feita pelo email ou
documento. No caso de contas transparentes, este método funciona se
utilizado documento mas se passar o email, retorna sempre 404.